### PR TITLE
Replace curly braces with brackets (deprecated in PHP 7.4)

### DIFF
--- a/src/Reader/Bz2DumpReader.php
+++ b/src/Reader/Bz2DumpReader.php
@@ -75,7 +75,7 @@ class Bz2DumpReader implements DumpReader {
 				return null;
 			}
 		}
-		while ( $line === '' || $line{0} !== '{' );
+		while ( $line === '' || $line[0] !== '{' );
 
 		return rtrim( $line, ",\n\r" );
 	}

--- a/src/Reader/ExtractedDumpReader.php
+++ b/src/Reader/ExtractedDumpReader.php
@@ -82,7 +82,7 @@ class ExtractedDumpReader implements SeekableDumpReader {
 				return null;
 			}
 
-			if ( $line{0} === '{' ) {
+			if ( $line[0] === '{' ) {
 				return rtrim( $line, ",\n\r" );
 			}
 		}

--- a/src/Reader/GzDumpReader.php
+++ b/src/Reader/GzDumpReader.php
@@ -85,7 +85,7 @@ class GzDumpReader implements SeekableDumpReader {
 				return null;
 			}
 		}
-		while ( $line === '' || $line{0} !== '{' );
+		while ( $line === '' || $line[0] !== '{' );
 
 		return rtrim( $line, ",\n\r" );
 	}


### PR DESCRIPTION
Hi @JeroenDeDauw. This should fix curly braces access deprecation (7.4) and removal (8.0) issues mentioned in #2 